### PR TITLE
Fix: Handle string | boolean in highAlert filter toggle

### DIFF
--- a/src/components/medications/MedicationFilters.tsx
+++ b/src/components/medications/MedicationFilters.tsx
@@ -16,7 +16,7 @@ interface MedicationFiltersProps {
     route: string;
   };
   onStringFilterChange: (key: 'patientType' | 'classification' | 'route', value: string) => void;
-  onHighAlertToggle: (value: boolean) => void;
+  onHighAlertToggle: (value: string | boolean) => void; // MODIFIED
   onClearFilters: () => void;
   activeFiltersCount: number;
 }

--- a/src/hooks/useMedicationFilters.ts
+++ b/src/hooks/useMedicationFilters.ts
@@ -28,7 +28,7 @@ interface UseMedicationFiltersReturn {
   filteredMedications: Medication[];
   activeFiltersCount: number;
   handleStringFilterChange: (key: 'patientType' | 'classification' | 'route', value: string) => void;
-  handleHighAlertToggle: (value: boolean) => void;
+  handleHighAlertToggle: (value: string | boolean) => void; // MODIFIED
   clearFilters: () => void;
   handleCategorySelect: (categoryId: string) => void;
 }
@@ -99,8 +99,9 @@ export const useMedicationFilters = ({
     setFilters(prev => ({ ...prev, [key]: value }));
   };
 
-  const handleHighAlertToggle = (value: boolean) => {
-    setFilters(prev => ({ ...prev, highAlert: value }));
+  const handleHighAlertToggle = (value: string | boolean) => {
+    const booleanValue = value === true || value === 'true' || value === 'checked';
+    setFilters(prev => ({ ...prev, highAlert: booleanValue }));
   };
 
   const clearFilters = () => {


### PR DESCRIPTION
Resolved a TypeScript error where the Switch component's onCheckedChange prop, potentially providing a value of type 'string | boolean', was incompatible with the onHighAlertToggle handler which expected a strict boolean.

Modified handleHighAlertToggle in useMedicationFilters.ts to accept 'string | boolean' and correctly convert the value to a boolean before updating the state. Updated relevant type definitions in useMedicationFilters.ts and MedicationFilters.tsx accordingly.