### PR TITLE
Fix: Remove deprecated onError and address type issues in MedicationD…

### DIFF
--- a/src/pages/MedicationDetail.tsx
+++ b/src/pages/MedicationDetail.tsx
@@ -69,18 +69,12 @@ const MedicationDetail = () => {
     queryKey: ['medication-indications', id],
     queryFn: () => fetchMedicationData('medication_indications'),
     enabled: !!id && !!medication,
-    onError: (error) => {
-      console.error('Error fetching indications:', error);
-    },
   });
 
   const { data: contraindications } = useQuery({
     queryKey: ['medication-contraindications', id],
     queryFn: () => fetchMedicationData('medication_contraindications'),
     enabled: !!id && !!medication,
-    onError: (error) => {
-      console.error('Error fetching contraindications:', error);
-    },
   });
 
   const { data: dosing } = useQuery({
@@ -103,9 +97,6 @@ const MedicationDetail = () => {
       return data;
     },
     enabled: !!id && !!medication,
-    onError: (error) => {
-      console.error('Error fetching dosing:', error);
-    },
   });
 
   const { data: administration } = useQuery({
@@ -115,9 +106,6 @@ const MedicationDetail = () => {
       return data?.[0];
     },
     enabled: !!id && !!medication,
-    onError: (error) => {
-      console.error('Error fetching administration:', error);
-    },
   });
 
   const handleBackClick = () => navigate(-1);


### PR DESCRIPTION
…etail

Removed deprecated `onError` callback from `useQuery` hooks in `src/pages/MedicationDetail.tsx` as it's no longer supported in TanStack Query v5.

This change also resolves related TypeScript errors (TS2769, TS2322, TS2740) that were occurring due to the incorrect usage of `onError` and its impact on type inference for the query's data property.

Error handling is managed by toast notifications within query functions and by relying on `react-query` to set data to `undefined` on error, which is handled by downstream components.